### PR TITLE
fix: interpret the angular velocity vector in the source frame

### DIFF
--- a/tasks/PoseAndTwistFrameChangeRBSTask.cpp
+++ b/tasks/PoseAndTwistFrameChangeRBSTask.cpp
@@ -39,7 +39,8 @@ void PoseAndTwistFrameChangeRBSTask::source2ref_samplesTransformerCallback(
     target2ref_rbs.position = target2ref.translation();
     target2ref_rbs.orientation = target2ref.rotation();
     target2ref_rbs.velocity = source2ref_rbs.velocity + induced_velocity_ref;
-    target2ref_rbs.angular_velocity = source2ref_rbs.angular_velocity;
+    target2ref_rbs.angular_velocity =
+        source2target_pose.rotation() * source2ref_rbs.angular_velocity;
     _target2ref_samples.write(target2ref_rbs);
 }
 

--- a/tasks/PoseAndTwistFrameChangeRBSTask.cpp
+++ b/tasks/PoseAndTwistFrameChangeRBSTask.cpp
@@ -28,7 +28,7 @@ void PoseAndTwistFrameChangeRBSTask::source2ref_samplesTransformerCallback(
     Eigen::Affine3d target2ref = source2ref * source2target_pose.inverse();
 
     Eigen::Vector3d induced_velocity_ref =
-        source2ref_rbs.angular_velocity
+        (source2ref_rbs.orientation * source2ref_rbs.angular_velocity)
         .cross(source2ref_rot * source2target_pose.inverse().translation());
 
     base::samples::RigidBodyState target2ref_rbs;

--- a/test/PoseAndTwistFrameChangeRBSTask_test.rb
+++ b/test/PoseAndTwistFrameChangeRBSTask_test.rb
@@ -95,7 +95,7 @@ describe OroGen.transforms.PoseAndTwistFrameChangeRBSTask do
     end
 
     it "handles the target and reference having different orientations" do
-        target_q = Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ)
+        target_q = Eigen::Quaternion.from_angle_axis(Math::PI / 2, Eigen::Vector3.UnitZ)
         configure_target2source translation: Eigen::Vector3.UnitY, rotation: target_q
         syskit_configure_and_start @task
 
@@ -111,7 +111,7 @@ describe OroGen.transforms.PoseAndTwistFrameChangeRBSTask do
         assert_eigen_approx @source2ref.position + Eigen::Vector3.UnitY, target2ref.position
         assert_eigen_approx target_q, target2ref.orientation
         assert_eigen_approx @source2ref.velocity + Eigen::Vector3.UnitZ, target2ref.velocity
-        assert_eigen_approx @source2ref.angular_velocity, target2ref.angular_velocity
+        assert_eigen_approx -Eigen::Vector3.UnitY, target2ref.angular_velocity
     end
 
     # The target orientation does not affect the result, but it does affect the
@@ -120,11 +120,11 @@ describe OroGen.transforms.PoseAndTwistFrameChangeRBSTask do
         source2ref_q = Eigen::Quaternion.from_angle_axis(
             Math::PI / 2, Eigen::Vector3.UnitX
         )
-        target2ref_q = Eigen::Quaternion.from_angle_axis(
-            Math::PI / 2, Eigen::Vector3.UnitY
+        target2source_q = Eigen::Quaternion.from_angle_axis(
+            Math::PI / 2, Eigen::Vector3.UnitZ
         )
         configure_target2source translation: Eigen::Vector3.UnitY,
-                                rotation: target2ref_q
+                                rotation: target2source_q
         syskit_configure_and_start @task
 
         @source2ref.position = Eigen::Vector3.new(rand, rand, rand)
@@ -138,9 +138,10 @@ describe OroGen.transforms.PoseAndTwistFrameChangeRBSTask do
 
         assert_eigen_approx @source2ref.position + Eigen::Vector3.UnitZ,
                             target2ref.position
-        assert_eigen_approx source2ref_q * target2ref_q, target2ref.orientation
-        assert_eigen_approx @source2ref.velocity - Eigen::Vector3.UnitY, target2ref.velocity
-        assert_eigen_approx @source2ref.angular_velocity, target2ref.angular_velocity
+        assert_eigen_approx source2ref_q * target2source_q, target2ref.orientation
+        assert_eigen_approx @source2ref.velocity - Eigen::Vector3.UnitY,
+                            target2ref.velocity
+        assert_eigen_approx -Eigen::Vector3.UnitY, target2ref.angular_velocity
     end
 
 


### PR DESCRIPTION
As the RigidBodyState documentation states, the angular velocity
vector is the velocity of the source w.r.t the target, but expressed
in the source frame - this is also what IMUs / INS traditionally send
as it matches the gyro readings 1:1