### PR TITLE
feat: add PoseCombinationRBSTask

### DIFF
--- a/tasks/PoseCombinationRBSTask.cpp
+++ b/tasks/PoseCombinationRBSTask.cpp
@@ -1,0 +1,71 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "PoseCombinationRBSTask.hpp"
+
+using namespace transforms;
+
+PoseCombinationRBSTask::PoseCombinationRBSTask(std::string const& name)
+    : PoseCombinationRBSTaskBase(name)
+{
+}
+
+PoseCombinationRBSTask::~PoseCombinationRBSTask()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See PoseCombinationRBSTask.hpp for more detailed
+// documentation about them.
+
+bool PoseCombinationRBSTask::configureHook()
+{
+    if (! PoseCombinationRBSTaskBase::configureHook())
+        return false;
+    return true;
+}
+bool PoseCombinationRBSTask::startHook()
+{
+    if (! PoseCombinationRBSTaskBase::startHook())
+        return false;
+    return true;
+}
+void PoseCombinationRBSTask::updateHook()
+{
+    base::samples::RigidBodyState object2ref_rbs;
+    if (_object2ref_pose.read(object2ref_rbs) == RTT::NoData) {
+        return;
+    }
+
+    base::samples::RigidBodyState newref2ref_rbs;
+    if (_newref2ref_pose.read(newref2ref_rbs) != RTT::NewData) {
+        return;
+    }
+
+    Eigen::Affine3d object2ref = object2ref_rbs;
+    Eigen::Affine3d newref2ref = newref2ref_rbs;
+    Eigen::Affine3d ref2newref = newref2ref.inverse();
+    Eigen::Affine3d object2newref = ref2newref * object2ref;
+    base::samples::RigidBodyState object2newref_rbs;
+    object2newref_rbs.time = std::min(object2ref_rbs.time, newref2ref_rbs.time);
+    object2newref_rbs.position = object2newref.translation();
+    object2newref_rbs.orientation = object2newref.rotation();
+    object2newref_rbs.velocity = ref2newref.rotation() * object2ref_rbs.velocity;
+    object2newref_rbs.angular_velocity = object2ref_rbs.angular_velocity;
+    _object2newref_pose.write(object2newref_rbs);
+
+    PoseCombinationRBSTaskBase::updateHook();
+}
+void PoseCombinationRBSTask::errorHook()
+{
+    PoseCombinationRBSTaskBase::errorHook();
+}
+void PoseCombinationRBSTask::stopHook()
+{
+    PoseCombinationRBSTaskBase::stopHook();
+}
+void PoseCombinationRBSTask::cleanupHook()
+{
+    PoseCombinationRBSTaskBase::cleanupHook();
+}

--- a/tasks/PoseCombinationRBSTask.hpp
+++ b/tasks/PoseCombinationRBSTask.hpp
@@ -1,0 +1,107 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef TRANSFORMS_POSECOMBINATIONRBSTASK_TASK_HPP
+#define TRANSFORMS_POSECOMBINATIONRBSTASK_TASK_HPP
+
+#include "transforms/PoseCombinationRBSTaskBase.hpp"
+
+namespace transforms{
+
+    /*! \class PoseCombinationRBSTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * Task that takes object2ref and newref2ref, and computes object2newref
+
+'newref' is considered fixed in 'ref' for this calculation. That is, the
+linear velocity is rotated to match b's orientation, but the velocities are
+not combined
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','transforms::PoseCombinationRBSTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     */
+    class PoseCombinationRBSTask : public PoseCombinationRBSTaskBase
+    {
+	friend class PoseCombinationRBSTaskBase;
+    protected:
+
+
+
+    public:
+        /** TaskContext constructor for PoseCombinationRBSTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        PoseCombinationRBSTask(std::string const& name = "transforms::PoseCombinationRBSTask");
+
+        /** Default deconstructor of PoseCombinationRBSTask
+         */
+	~PoseCombinationRBSTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+

--- a/test/PoseCombinationRBSTask_test.rb
+++ b/test/PoseCombinationRBSTask_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+using_task_library "transforms"
+
+describe OroGen.transforms.PoseCombinationRBSTask do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen.transforms.PoseCombinationRBSTask
+                  .deployed_as("task_under_test")
+        )
+        # Set up properties with @task.properties....=
+        syskit_configure(@task)
+    end
+
+    after do
+    end
+
+    it "performs the transformation" do
+        syskit_start(@task)
+
+        t0 = make_rock_time
+        a2ref = Types.base.samples.RigidBodyState.Invalid
+        a2ref.time = t0 + 1
+        a2ref.position = Eigen::Vector3.new(1, 2, 3)
+        a2ref.orientation =
+            Eigen::Quaternion.from_angle_axis(-Math::PI/2, Eigen::Vector3.UnitZ)
+        a2ref.velocity = Eigen::Vector3.new(5, 1, 2)
+        a2ref.angular_velocity = Eigen::Vector3.new(rand, rand, rand)
+
+        b2ref = Types.base.samples.RigidBodyState.Invalid
+        b2ref.time = t0
+        b2ref.position = Eigen::Vector3.new(4, 3, 2)
+        b2ref.orientation =
+            Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ)
+        b2ref.velocity = Eigen::Vector3.new(rand, rand, rand)
+        b2ref.angular_velocity = Eigen::Vector3.new(rand, rand, rand)
+
+        a2b = expect_execution do
+            syskit_write task.object2ref_pose_port, a2ref
+            syskit_write task.newref2ref_pose_port, b2ref
+        end.to { have_one_new_sample task.object2newref_pose_port }
+
+        assert_equal t0, a2b.time
+        assert_approx Eigen::Vector3.new(-1, 3, 1), a2b.position
+        assert_approx Eigen::Quaternion.from_angle_axis(Math::PI, Eigen::Vector3.UnitZ),
+                      a2b.orientation
+        assert_approx Eigen::Vector3.new(1, -5, 2), a2b.velocity
+        assert_approx a2ref.angular_velocity, a2b.angular_velocity
+    end
+
+    def assert_approx(a, b)
+        assert a.approx?(b), "#{b} was expected to be approximately equal to #{a}"
+    end
+
+    def make_rock_time
+        now = Time.now
+        Time.at(now.tv_sec, now.tv_usec)
+    end
+end

--- a/transforms.orogen
+++ b/transforms.orogen
@@ -35,3 +35,19 @@ task_context "PoseAndTwistFrameChangeRBSTask" do
 
     port_driven
 end
+
+# Task that takes two poses relative to a single reference and outputs the one
+# relative to the other
+#
+# 'newref' is considered fixed in 'ref' for this calculation. That is, the
+# linear velocity is rotated to match b's orientation, but the velocities are
+# not combined
+task_context "PoseCombinationRBSTask" do
+    needs_configuration
+
+    input_port "object2ref_pose", "/base/samples/RigidBodyState"
+    input_port "newref2ref_pose", "/base/samples/RigidBodyState"
+
+    output_port "object2newref_pose", "/base/samples/RigidBodyState"
+    port_driven
+end


### PR DESCRIPTION
The task combines two transforms a2ref and b2ref into a2b, considering
that b is fixed in ref for the purpose of velocity calculations.

It does not transform the covariance matrices (they are unset on the
output), but does transform position, orientation, velocity and
angular_velocity.