### PR TITLE
fix: add an initialization phase to RedundantRBSSelector

### DIFF
--- a/tasks/RedundantRBSSelectorTask.hpp
+++ b/tasks/RedundantRBSSelectorTask.hpp
@@ -39,6 +39,7 @@ namespace transforms {
             {
             }
 
+            base::Time init_deadline;
             base::Time main_source_deadline;
             base::Time secondary_source_deadline;
 
@@ -47,11 +48,9 @@ namespace transforms {
              * after being invalid
              */
             base::Time hysteresis_deadline;
-
         };
 
     protected:
-        bool m_first_cycle;
         base::Time m_source_timeout;
         base::Time m_main_source_hysteresis;
 

--- a/transforms.orogen
+++ b/transforms.orogen
@@ -85,6 +85,10 @@ end
 task_context "RedundantRBSSelectorTask" do
     needs_configuration
 
+    # How long the component should wait after its start to evaluate whether
+    # it has missing inputs
+    property "init_timeout", "/base/Time"
+
     # How long without valid data on a port before the source is considered
     # invalid
     #


### PR DESCRIPTION
The current implementation was transitioning unconditionally to
BOTH_SOURCES_VALID on init. Beyond causing a heisenbug (all 'start' should wait
for the event before going on), it is, you know, not true.

Add an initialization timeout during which the component will wait having enough
information to decide in which state it is, with a shortcut for
BOTH_SOURCES_VALID.